### PR TITLE
Add release functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,3 +168,5 @@ tags
 # End of https://www.toptal.com/developers/gitignore/api/go,vim,macos,intellij+all
 
 bin
+
+dist/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,25 @@
+before:
+  hooks:
+    - go mod tidy
+builds:
+  - main: ./cmd/deps
+    binary: codesee-deps-go
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+archives:
+  - replacements:
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+      386: i386
+      amd64: x86_64
+checksum:
+  name_template: 'checksums.txt'
+release:
+  github:
+    owner: Codesee-io
+    name: codesee-deps-go

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,26 @@ install:
 	@echo "---> Installing dependencies"
 	go mod download
 
+.PHONY: release
+release: $(BIN_DIR)/goreleaser
+	@echo "---> Creating new release"
+ifndef TAG
+	$(error TAG must be specified)
+endif
+ifndef GITHUB_TOKEN
+	$(error GITHUB_TOKEN must be specified. Generate one here: https://github.com/settings/tokens/new)
+endif
+	sed -i "" "s/version-.*-green/version-$(TAG)-green/" README.md
+	git add README.md
+	git commit -m $(TAG)
+	git tag $(TAG)
+	git push origin main --tags
+	$(BIN_DIR)/goreleaser release --rm-dist
+
+$(BIN_DIR)/goreleaser:
+	@echo "---> Installing goreleaser"
+	curl -sfL https://install.goreleaser.com/github.com/goreleaser/goreleaser.sh | sh
+
 .PHONY: test
 test:
 	@echo "---> Testing"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # codesee-deps-go
 
+[![Version](https://img.shields.io/badge/version-v0.0.0-green.svg)](https://github.com/Codesee-io/codesee-deps-go/releases)
+
 A command line tool that gives you a list of all usages between files within a
 project, while ignoring external dependencies.
 
@@ -65,3 +67,24 @@ go run ./cmd/deps .
 go run ./cmd/deps ./pkg/testdata/simple-repo
 go run /path/to/other/project
 ```
+
+### Releasing
+
+To make a new release, you need to have a GitHub token with `repo` permissions.
+You can generate one [here](https://github.com/settings/tokens/new). Once you
+have it, you just need to run the following command:
+
+```sh
+GITHUB_TOKEN=<github_token> TAG=<new_tag> make release
+# e.g.
+GITHUB_TOKEN=TOKEN TAG=v1.0.0 make release
+```
+
+This does the following:
+
+- Changes the version number in the `README.md`
+- Commits the change with the `TAG` as the commit message
+- Creates a tag with the specified `TAG`
+- Pushes the commit and tag to GitHub
+- Runs `goreleaser` to generate the binaries and uploads them to GitHub as a new
+  release

--- a/cmd/deps/main.go
+++ b/cmd/deps/main.go
@@ -4,15 +4,27 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/Codesee-io/codesee-deps-go/pkg/errutils"
 	"github.com/Codesee-io/codesee-deps-go/pkg/links"
+)
+
+var (
+	version = "dev"
+	commit  = "dev"
+	date    = time.Now().Format(time.RFC3339)
 )
 
 func main() {
 	if len(os.Args) < 2 {
 		fmt.Println("Usage: codesee-deps-go <directory>")
 		os.Exit(1)
+	}
+
+	if os.Args[1] == "-v" || os.Args[1] == "--version" {
+		fmt.Printf("codesee-deps-go version %s\ncommit: %s\nbuilt at: %s\n", version, commit, date)
+		os.Exit(0)
 	}
 
 	root := os.Args[1]


### PR DESCRIPTION
### What

- Add `.goreleaser.yml`
- Add `make release`
- Add version badge to the `README.md` (mostly just to have something to change/commit on every release)
- Add instructions on how to run it in the `README.md`
- Add support for calling the command with `-v` or `--version`. We might want to move to using [`cobra`](https://github.com/spf13/cobra) if this gets any bigger, but this is probably fine for now.