### PR TITLE
Refine .goreleaser.yml

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,16 +7,8 @@ builds:
     env:
       - CGO_ENABLED=0
     goos:
-      - linux
-      - windows
       - darwin
-archives:
-  - replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      386: i386
-      amd64: x86_64
+      - linux
 checksum:
   name_template: 'checksums.txt'
 release:


### PR DESCRIPTION
### What

- We don't need to build for Windows right now
- The sample replacements aren't necessary