### PR TITLE
Add replacements to .goreleaser.yml

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,6 +9,12 @@ builds:
     goos:
       - darwin
       - linux
+archives:
+  - replacements:
+      darwin: Darwin
+      linux: Linux
+      386: i386
+      amd64: x86_64
 checksum:
   name_template: 'checksums.txt'
 release:


### PR DESCRIPTION
### What

I now understand what the replacements are for; it's to match the default formatting of `uname` calls. `uname -m` returns `x86_64` instead of `amd64` for 64-bit machines, and `uname -s` is capitalized. This will make it easier to dynamically install it.