### PR TITLE
Edit replacements to .goreleaser.yml to match what Node returns

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,10 +11,8 @@ builds:
       - linux
 archives:
   - replacements:
-      darwin: Darwin
-      linux: Linux
-      386: i386
-      amd64: x86_64
+      386: x32
+      amd64: x64
 checksum:
   name_template: 'checksums.txt'
 release:


### PR DESCRIPTION
### What

We plan on using Node to download this, and so if we use Node's builtins to determine the [OS](https://nodejs.org/api/os.html#os_os_platform) and [architecture](https://nodejs.org/api/os.html#os_os_arch), we need it to be in this format.