### PR TITLE
Sort the links and don't pretty-print the JSON

### DIFF
--- a/cmd/deps/main.go
+++ b/cmd/deps/main.go
@@ -33,7 +33,7 @@ func main() {
 		errutils.Fatal(err)
 	}
 
-	out, err := json.MarshalIndent(l, "", "  ")
+	out, err := json.Marshal(l)
 	if err != nil {
 		errutils.Fatal(err)
 	}

--- a/pkg/links/links.go
+++ b/pkg/links/links.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"go/ast"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/Codesee-io/codesee-deps-go/pkg/parser"
@@ -292,6 +293,16 @@ func DetermineLinks(root string) ([]Link, error) {
 			}
 		}
 	}
+
+	// Sort the slice since its order isn't deterministic. While it doesn't need
+	// to be sorted, it helps if it is. And it's probably faster to sort it here
+	// than to do it downstream.
+	sort.Slice(links, func(i, j int) bool {
+		if links[i].From == links[j].From {
+			return links[i].To < links[j].To
+		}
+		return links[i].From < links[j].From
+	})
 
 	return links, nil
 }

--- a/pkg/links/links_test.go
+++ b/pkg/links/links_test.go
@@ -1,7 +1,6 @@
 package links
 
 import (
-	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -15,13 +14,6 @@ func TestDetermineLinks(t *testing.T) {
 		links, err := DetermineLinks(root)
 		require.NoError(tt, err)
 
-		// Sort the slice since its order isn't deterministic.
-		sort.Slice(links, func(i, j int) bool {
-			if links[i].From == links[j].From {
-				return links[i].To < links[j].To
-			}
-			return links[i].From < links[j].From
-		})
 		assert.Equal(tt, []Link{
 			{From: "cmd/api/main.go", To: "pkg/server/server.go"},
 			{From: "cmd/api/main.go", To: "pkg/signals/signals.go"},


### PR DESCRIPTION
### What

- Sort the links by `from` and then `to` so it's returned deterministically.
- Don't pretty-print the JSON output. This is unnecessary and makes the output much bigger. If we need to pretty-print it, we can use `jq`.