### PR TITLE
Fix small security issues

### DIFF
--- a/pkg/errutils/errors.go
+++ b/pkg/errutils/errors.go
@@ -23,7 +23,7 @@ type stackTracer interface {
 func Fatal(err error) {
 	stack := ErrStack(err)
 	fmt.Println(err.Error())
-	fmt.Println(string(stack))
+	fmt.Fprintln(os.Stderr, string(stack))
 	os.Exit(1)
 }
 

--- a/pkg/testdata/simple-repo/pkg/handlers/handlers.go
+++ b/pkg/testdata/simple-repo/pkg/handlers/handlers.go
@@ -6,5 +6,5 @@ import (
 )
 
 func Handler(w http.ResponseWriter, r *http.Request) {
-	fmt.Fprintf(w, "Hello %s", r.URL.Path[1:])
+	fmt.Fprintf(w, "Hello World")
 }


### PR DESCRIPTION
### What

- Print fatal stack traces to stderr instead of stdout since stack traces could contain sensitive information. In our case, it's a CLI, so it would only be exposing debugging information for the machine that it's running on, so it wouldn't really be a problem to begin with.
- Don't respond with the contents of a user-inputed URL. This can lead to XSS in general, though in our case, it's only test files that aren't ever run, so it's not a major issue for us.

### Why

These are reported as high vulnerabilities according to Snyk.